### PR TITLE
Instance method support.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,6 @@
 import unittest
 from multimethods import (MultiMethod, Default, type_dispatch, DispatchException, Anything,
-                          multimethod, is_a)
+                          multimethod, singledispatch, multidispatch, is_a)
 from collections import Iterable
 identity = lambda x: x
 
@@ -285,3 +285,45 @@ class IsA(unittest.TestCase):
         self.assertEqual(self.something(6), 5)
         self.assertEqual(self.something(-10), 0)
         self.assertEqual(self.something(25), 25)
+
+
+class Decorators(unittest.TestCase):
+
+    def test_singledispatch(self):
+        @singledispatch
+        def mm(value):
+            return 'default', value
+
+        @mm.method(dict)
+        def mm_int(value):
+            return 'dict', value
+
+        @mm.method(str)
+        def mm_str(value):
+            return 'str', value
+
+        @mm.method(float)
+        def mm_str(value):
+            return 'float', value
+
+        self.assertEqual(mm({}), ('dict', {}))
+        self.assertEqual(mm(12345), ('default', 12345))
+        self.assertEqual(mm(123.45), ('float', 123.45))
+        self.assertEqual(mm('foo'), ('str', 'foo'))
+
+    def test_multiispatch(self):
+        @multidispatch
+        def mm(*args):
+            return 'default', args
+
+        @mm.method((dict, list))
+        def mm_int(a, b):
+            return 'dict+list', a, b
+
+        @mm.method((str, float))
+        def mm_str(a, b):
+            return 'str+float', a, b
+
+        self.assertEqual(mm({}, []), ('dict+list', {}, []))
+        self.assertEqual(mm(12345), ('default', (12345,)))
+        self.assertEqual(mm('foo', 123.45), ('str+float', 'foo', 123.45))


### PR DESCRIPTION
I was looking for a solid multimethod library and came across your project.  As it happened, I was already 2 days into my own implementation when I decided to look deeper into what the Python community did in this area.  Thank you for writing this project all those years ago.

The only thing that seemed to be missing was the ability to use ``self`` on dispatched class methods.  I wrote this patch to provide that support, both as an optional argument on MultiMethod, and as a feature flag (so the default behavior may be set globally).  This way, the implementation can remain backwards compatible with existing code.

Some of the decorators in the library couldn't be modified, due to quirks in Python's implementation of decorators.  So ``@singledispatch`` and ``@multidispatch`` do not support the ``pass_self`` argument like ``@multimethod`` does.

In making sure that my changes didn't break existing behavior, I wrote additional tests for my own code, as well as those for the decorators in the library.  The decorator tests are their own commit - feel free to cherry-pick that one if you like.

FYI, this changeset does not modify the version number.  Should all this meet with your approval, I would be happy to add an additional commit for whatever version you think is appropriate. 

Thank you for your consideration.  I hope this PR finds you well.